### PR TITLE
Add read_unsigned_int and write_unsigned_int

### DIFF
--- a/data_input_stream.py
+++ b/data_input_stream.py
@@ -17,7 +17,7 @@ class DataInputStream:
 
     def read_unsigned_byte(self):
         return struct.unpack('B', self.stream.read(1))[0]
-    
+
     def read_char(self):
         return chr(struct.unpack('>H', self.stream.read(2))[0])
 
@@ -42,3 +42,6 @@ class DataInputStream:
 
     def read_int(self):
         return struct.unpack('>i', self.stream.read(4))[0]
+
+    def read_unsigned_int(self):
+        return struct.unpack('>I', self.stream.read(4))[0]

--- a/data_output_stream.py
+++ b/data_output_stream.py
@@ -42,3 +42,6 @@ class DataOutputStream:
 
     def write_int(self, val):
         self.stream.write(struct.pack('>i', val))
+
+    def write_unsigned_int(self, val):
+        self.stream.write(struct.pack('>I', val))


### PR DESCRIPTION
We use your classes in the open-dis-python project, but we required `read`/`write_unsigned_int` methods which are in this pull request.

Later if your library were published as a python package (PyPi) we could add it to our project as a dependency instead of including the raw source files. That would be pretty cool.